### PR TITLE
Test that Web Dispatch logs source IP address and path

### DIFF
--- a/test/src/rabbit_web_dispatch_test.erl
+++ b/test/src/rabbit_web_dispatch_test.erl
@@ -57,13 +57,14 @@ log_source_address_test() ->
 
     %% Then: log written WITH source IP address AND path.
     true = logged(source()),
-    true = logged(path  ()).
+    true = logged(path  ()),
+    true = logged(binary(status())).
 
 
 %% Ancillary procedures for log test
 
 %% Resource for testing with.
-path() -> <<"/wonderland">>.
+path() -> <<"wonderland">>.
 
 %% HTTP server port.
 port() -> 4096.
@@ -83,7 +84,7 @@ reason() -> <<"Testing, testing... 1, 2, 3.">>.
 
 %% HTTP server forwarding table.
 table() ->
-    cowboy_router:compile([{source(), [{path(), ?MODULE, []}]}]).
+    cowboy_router:compile([{source(), [{"/" ++ string(path()), ?MODULE, []}]}]).
 
 %% Cowboy handler callbacks.
 init(_, Request, _) ->
@@ -118,8 +119,11 @@ logged(Handle, Text) ->
             end
     end.
 
-%% Convenience procedure.
+%% Convenience procedures.
 string(N) when is_integer(N) ->
     erlang:integer_to_list(N);
 string(B) when is_binary(B) ->
     erlang:binary_to_list(B).
+
+binary(N) when is_integer(N) ->
+    erlang:integer_to_binary(N).

--- a/test/src/rabbit_web_dispatch_test.erl
+++ b/test/src/rabbit_web_dispatch_test.erl
@@ -71,7 +71,7 @@ port() -> 4096.
 
 %% Log files will be written here.
 log_directory() ->
-    "/tmp/rabbit/test/".
+    os:getenv("RABBITMQ_LOG_BASE") ++ "/".
 
 %% Source IP address of request.
 source() -> <<"127.0.0.1">>.

--- a/test/src/rabbit_web_dispatch_test.erl
+++ b/test/src/rabbit_web_dispatch_test.erl
@@ -18,6 +18,10 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% Silence compiler warnings. These *are* used: callbacks for a Cowboy
+%% test handler.
+-export([init/3, handle/2, terminate/3]).
+
 query_static_resource_test() ->
     application:start(inets),
 
@@ -38,3 +42,84 @@ add_idempotence_test() ->
        1, length([ok || {"/foo", _, _} <-
                             rabbit_web_dispatch_registry:list_all()])),
     passed.
+
+log_source_address_test() ->
+
+    %% Given: everything in place to issue AND log an HTTP response.
+    {ok, _} = rabbit_web_dispatch:register_context_handler(log_response_test,
+        [{port, port()}], path(), table(), description()),
+    ok = webmachine_log:add_handler(webmachine_log_handler, [log_directory()]),
+
+    %% When: when a client makes a request.
+    {ok, _Response} = httpc:request(get, {"http://127.0.0.1:" ++
+        string(port()) ++ "/" ++ string(path()), []}, [],
+        [{ip, string(source())}]),
+
+    %% Then: log written WITH source IP address AND path.
+    true = logged(source()),
+    true = logged(path  ()).
+
+
+%% Ancillary procedures for log test
+
+%% Resource for testing with.
+path() -> <<"/wonderland">>.
+
+%% HTTP server port.
+port() -> 4096.
+
+%% Log files will be written here.
+log_directory() ->
+    "/tmp/rabbit/test/".
+
+%% Source IP address of request.
+source() -> <<"127.0.0.1">>.
+
+description() -> "Test that source IP address is logged upon HTTP response.".
+
+status() -> 500.
+
+reason() -> <<"Testing, testing... 1, 2, 3.">>.
+
+%% HTTP server forwarding table.
+table() ->
+    cowboy_router:compile([{source(), [{path(), ?MODULE, []}]}]).
+
+%% Cowboy handler callbacks.
+init(_, Request, _) ->
+    {ok, Request, no_state}.
+
+handle(Request, St) ->
+    {ok, Response} = cowboy_req:reply(status(), [{<<"content-type">>,
+        <<"text/plain">>}], reason(), Request),
+    {ok, Response, St}.
+
+terminate(_, _, _) ->
+    ok.
+
+%% Predicate: the given `Text` is read from file.
+logged(Text) ->
+    {ok, Handle} = file:open(log_directory() ++
+        "access.log" ++ webmachine_log:suffix(webmachine_log:datehour()),
+        [read, binary]),
+    logged(Handle, Text).
+
+logged(Handle, Text) ->
+    case io:get_line(Handle, "") of
+        eof ->
+            file:close(Handle),
+            false;
+        Line when is_binary(Line) ->
+            case binary:matches(Line, Text) of
+                [] ->
+                    logged(Handle, Text);
+                [{N,_}] when is_integer(N), N >= 0 ->
+                    true
+            end
+    end.
+
+%% Convenience procedure.
+string(N) when is_integer(N) ->
+    erlang:integer_to_list(N);
+string(B) when is_binary(B) ->
+    erlang:binary_to_list(B).


### PR DESCRIPTION
This is general enough to test Web Dispatch with every application that does logging as it's done here. Indeed, the Management plugin _does_ log like this, so this closes https://github.com/rabbitmq/rabbitmq-server/issues/483.

Unlike the output given for issue #483 at https://groups.google.com/d/msg/rabbitmq-users/CBUYqqBwlg0/nsQwQD8HBQAJ the logging tested here doesn't log a **reason**, but it does log a **source** IP and **path**. Logging a **reason** wouldn't be much work.

Feedback on the directory the log is written out to would be appreciated.
