### PR TITLE
Remove any content-encoding header from error responses

### DIFF
--- a/src/rabbit_webmachine_error_handler.erl
+++ b/src/rabbit_webmachine_error_handler.erl
@@ -37,7 +37,8 @@ render_error_body(404,  Req, _)      -> error_body(404,  Req, "Not Found");
 render_error_body(Code, Req, Reason) -> error_body(Code, Req, Reason).
 
 error_body(Code, Req, Reason) ->
-    {ok, ReqState} = Req:add_response_header("Content-Type","application/json"),
+    {ok, ReqState0} = Req:add_response_header("Content-Type","application/json"),
+    {ok, ReqState} = Req:remove_response_header("Content-Encoding"),
     case Code of
         500 -> maybe_log(Req, Reason);
         _   -> ok


### PR DESCRIPTION
Part of https://github.com/rabbitmq/rabbitmq-management/issues/138 for stable.

Fixes issues reported in https://github.com/rabbitmq/rabbitmq-management/pull/154
