### PR TITLE
Ensure that cowboy_req:peer return values will not crash

### DIFF
--- a/src/webmachine_log_handler.erl
+++ b/src/webmachine_log_handler.erl
@@ -86,20 +86,25 @@ code_change(_OldVsn, State, _Extra) ->
 %% since we are now using Cowboy, a few small parts had to change.
 %% This is one such part. The code is however equivalent to Webmachine's.
 
-format_req({Status0, Body, Req}) ->
+format_req({Status0, Body, Req0}) ->
     User = "-",
     Time = webmachine_log:fmtnow(),
     Status = integer_to_list(Status0),
     Length = integer_to_list(iolist_size(Body)),
-    {Method, _} = cowboy_req:method(Req),
-    {Path, _} = cowboy_req:path(Req),
-    {{Peer, _}, _} = cowboy_req:peer(Req),
-    Version = case cowboy_req:version(Req) of
+    {Method, Req1} = cowboy_req:method(Req0),
+    {Path, Req2} = cowboy_req:path(Req1),
+    {Peer, Req3} = case cowboy_req:peer(Req2) of
+                       {{Peer0, _Port}, R} ->
+                           {Peer0, R};
+                       {Other, R} ->
+                           {Other, R}
+                   end,
+    Version = case cowboy_req:version(Req3) of
         {'HTTP/1.1', _} -> {1, 1};
         {'HTTP/1.0', _} -> {1, 0}
     end,
-    {Referer, _} = cowboy_req:header(<<"referer">>, Req, <<>>),
-    {UserAgent, _} = cowboy_req:header(<<"user-agent">>, Req, <<>>),
+    {Referer, Req4} = cowboy_req:header(<<"referer">>, Req3, <<>>),
+    {UserAgent, _Req5} = cowboy_req:header(<<"user-agent">>, Req4, <<>>),
     fmt_alog(Time, Peer, User, Method, Path, Version,
              Status, Length, Referer, UserAgent).
 


### PR DESCRIPTION
Fixes #27 

Since the type spec for cowboy_req:peer indicates that a two-tuple of {undefined, Req} can be returned we should handle this as `badmatch` could be the result otherwise.

I also used the returned value of Req as specified in the cowboy docs:

https://ninenines.eu/docs/en/cowboy/1.0/guide/req/

I realize this is pedantic and unnecessary in this case but it ensures that we can handle changes in cowboy should the API change in the future.