### PR TITLE
Fix rabbit_cowboy_redirect and remove unused optional callbacks

### DIFF
--- a/src/rabbit_cowboy_redirect.erl
+++ b/src/rabbit_cowboy_redirect.erl
@@ -16,17 +16,9 @@
 
 -module(rabbit_cowboy_redirect).
 
--export([init/3]).
--export([handle/2]).
--export([terminate/3]).
+-export([init/2]).
 
-init(_, Req, RedirectPort) ->
-    {ok, Req, RedirectPort}.
-
-handle(Req0, RedirectPort) ->
+init(Req0, RedirectPort) ->
     URI = cowboy_req:uri(Req0, #{port => RedirectPort}),
     Req = cowboy_req:reply(301, #{<<"location">> => URI}, Req0),
     {ok, Req, RedirectPort}.
-
-terminate(_, _, _) ->
-    ok.

--- a/src/rabbit_web_dispatch_listing_handler.erl
+++ b/src/rabbit_web_dispatch_listing_handler.erl
@@ -17,7 +17,6 @@
 -module(rabbit_web_dispatch_listing_handler).
 
 -export([init/2]).
--export([terminate/3]).
 
 init(Req0, Listener) ->
     HTMLPrefix =
@@ -35,6 +34,3 @@ init(Req0, Listener) ->
         end,
     Req = cowboy_req:reply(200, #{}, [HTMLPrefix, List, HTMLSuffix], Req0),
     {ok, Req, Listener}.
-
-terminate(_, _, _) ->
-    ok.


### PR DESCRIPTION
The handler rabbit_cowboy_redirect was apparently not converted
to Cowboy 2. It should work properly now.

Fix for https://github.com/rabbitmq/rabbitmq-web-dispatch/issues/31