### PR TITLE
Handle sendfile bodies when writing access logs

### DIFF
--- a/src/webmachine_log_handler.erl
+++ b/src/webmachine_log_handler.erl
@@ -90,7 +90,11 @@ format_req({Status0, Body, Req}) ->
     User = "-",
     Time = webmachine_log:fmtnow(),
     Status = integer_to_list(Status0),
-    Length = integer_to_list(iolist_size(Body)),
+    Length1 = case Body of
+        {sendfile, _, Length0, _} -> Length0;
+        _ -> iolist_size(Body)
+    end,
+    Length = integer_to_list(Length1),
     Method = cowboy_req:method(Req),
     Path = cowboy_req:path(Req),
     Peer = case cowboy_req:peer(Req) of


### PR DESCRIPTION
Fix for https://groups.google.com/forum/#!topic/rabbitmq-users/nLIiwJ32CEo

The steps to reproduce are:

* Configure `management.http_log_dir` to something like `/tmp/rabbitmq_access_logs` (this can be done in the Makefile of rabbitmq-management when using `make run-broker` for example)
* Start a node with management, `make run-broker` in management
* Tail the crash log `tail -F /tmp/rabbitmq-test-instances/rabbit/log/log/crash.log`
* Run `curl -i http://127.0.0.1:15672/api`
* The crash log will contain a crash report

The error does not occur when the configuration is not set because this code does not run when there are no access log files configured.