### PR TITLE
Replace compress option by cowboy_compress_h

### DIFF
--- a/src/rabbit_web_dispatch_sup.erl
+++ b/src/rabbit_web_dispatch_sup.erl
@@ -38,9 +38,9 @@ ensure_listener(Listener) ->
         _ ->
             {Transport, TransportOpts, ProtoOpts} = preprocess_config(Listener),
             ProtoOptsMap = maps:from_list(ProtoOpts),
-            rabbit_log:debug("Starting HTTP[S] listener with transport ~s, options ~p and protocol options ~p",
-                             [Transport, TransportOpts, ProtoOptsMap]),
             StreamHandlers = stream_handlers_config(ProtoOpts),
+            rabbit_log:debug("Starting HTTP[S] listener with transport ~s, options ~p and protocol options ~p, stream handlers ~p",
+                             [Transport, TransportOpts, ProtoOptsMap, StreamHandlers]),
             CowboyOptsMap =
                 maps:merge(#{env =>
                                 #{rabbit_listener => Listener},


### PR DESCRIPTION
Deprecated from cowboy 2.0
Note: Only streams > 300 bytes are compressed

Reported in https://groups.google.com/forum/?nomobile=true#!searchin/rabbitmq-users/compress%7Csort:date/rabbitmq-users/D_ZmwpTg_AU/O8Kn6pKDEAAJ