### PR TITLE
URL Cleanup

### DIFF
--- a/src/webmachine_log.erl
+++ b/src/webmachine_log.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an

--- a/src/webmachine_log_handler.erl
+++ b/src/webmachine_log_handler.erl
@@ -5,7 +5,7 @@
 %% except in compliance with the License.  You may obtain
 %% a copy of the License at
 %%
-%%   http://www.apache.org/licenses/LICENSE-2.0
+%%   https://www.apache.org/licenses/LICENSE-2.0
 %%
 %% Unless required by applicable law or agreed to in writing,
 %% software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).